### PR TITLE
Updates to make the driver build on 6.8 kernel. Also updated the Readme to add more information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ Example: https://www.aliexpress.us/item/3256807263559115.html
 
 To install: 
 $make
+
 $sudo make install
 
 
 You will have to reinstall for any kernel updates.
 $make clean
+
 $make
+
 $sudo make install

--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
-# rtl8831
-realtek 8851 8831 linux driver
+# RTL88X1
+Realtek Linux driver for USB AX900 Wifi 6 devices 8851bu and 8831bu
 
-This is for ipTIME AX900UA or Realtek 8851bu 8831bu chipset.
+This is for generic USB AX900 realtek devices that use the Realtek 8851bu or 8831bu chipsets.
+
+Examples include: 
+pTIME AX900UA
+Comfast AX900 CF-943F
+
+This includes unbranded AX900 USB WiFi 6 Bluetooth 5.3 Adapters sold on AliExpress and Amazon
+Example: https://www.aliexpress.us/item/3256807263559115.html
+
+To install: 
+$make
+$sudo make install
 
 
-make
-
-make install
-
-:)
+You will have to reinstall for any kernel updates.
+$make clean
+$make
+$sudo make install

--- a/include/drv_conf.h
+++ b/include/drv_conf.h
@@ -711,4 +711,8 @@ power down etc.) in last time, we can unmark this flag to avoid some unpredictab
 */
 #define RTW_WKARD_TRIGGER_FRAME_PARSER
 
+#if !defined(strlcpy)
+#define strlcpy(a, b, c) strscpy(a, b, c)
+#endif
+
 #endif /* __DRV_CONF_H__ */

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -5684,33 +5684,22 @@ static int rtw_cfg80211_set_beacon_ies(struct net_device *net, const u8 *head,
 }
 
 static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *ndev,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
+		struct cfg80211_ap_update *params)
+#else
 		struct cfg80211_beacon_data *info)
+#endif
 {
 	int ret = 0;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(ndev);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
+	struct cfg80211_beacon_data *info = &params->beacon;
+#endif
 
 	RTW_INFO(FUNC_NDEV_FMT"\n", FUNC_NDEV_ARG(ndev));
 
-#ifdef not_yet
-	/*
-	 * @proberesp_ies: extra information element(s) to add into Probe Response
-	 *	frames or %NULL
-	 * @proberesp_ies_len: length of proberesp_ies in octets
-	 */
-	if (info->proberesp_ies_len > 0)
-		rtw_cfg80211_set_proberesp_ies(ndev, info->proberesp_ies, info->proberesp_ies_len);
-#endif /* not_yet */
+	ret = rtw_add_beacon(adapter, info->head, info->head_len, info->tail, info->tail_len);
 
-	if (info->assocresp_ies_len > 0)
-		rtw_cfg80211_set_assocresp_ies(ndev, info->assocresp_ies, info->assocresp_ies_len);
-
-	if (rtw_cfg80211_check_beacon_ies(ndev, info->head, info->head_len,
-					  info->tail, info->tail_len) != 0) {
-		ret = rtw_add_beacon(adapter, info->head, info->head_len,
-				     info->tail, info->tail_len);
-		rtw_cfg80211_set_beacon_ies(ndev, info->head, info->head_len,
-					    info->tail, info->tail_len);
-	}
 	return ret;
 }
 

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -515,13 +515,13 @@ static void rtw_ethtool_get_drvinfo(struct net_device *dev, struct ethtool_drvin
 
 	wdev = dev->ieee80211_ptr;
 	if (wdev) {
-		strlcpy(info->driver, wiphy_dev(wdev->wiphy)->driver->name,
+		strscpy(info->driver, wiphy_dev(wdev->wiphy)->driver->name,
 			sizeof(info->driver));
 	} else {
-		strlcpy(info->driver, "N/A", sizeof(info->driver));
+		strscpy(info->driver, "N/A", sizeof(info->driver));
 	}
 
-	strlcpy(info->version, DRIVERVERSION, sizeof(info->version));
+	strscpy(info->version, DRIVERVERSION, sizeof(info->version));
 
 	padapter = (_adapter *)rtw_netdev_priv(dev);
 
@@ -538,10 +538,10 @@ static void rtw_ethtool_get_drvinfo(struct net_device *dev, struct ethtool_drvin
 	} else
 	#endif
 	{
-		strlcpy(info->fw_version, "N/A", sizeof(info->fw_version));
+		strscpy(info->fw_version, "N/A", sizeof(info->fw_version));
 	}
 
-	strlcpy(info->bus_info, dev_name(wiphy_dev(wdev->wiphy)),
+	strscpy(info->bus_info, dev_name(wiphy_dev(wdev->wiphy)),
 		sizeof(info->bus_info));
 }
 

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -216,7 +216,7 @@ struct rtw_usb_drv usb_drv = {
 	.usbdrv.reset_resume   = rtw_dev_resume,
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 19))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 19) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0))
 	.usbdrv.drvwrap.driver.shutdown = rtw_dev_shutdown,
 #else
 	.usbdrv.driver.shutdown = rtw_dev_shutdown,


### PR DESCRIPTION
I added these commits using information from the lwfinger rtw88 and rtw89 github repos. 

They allowed the driver to build on Ubuntu 24.04 kernel 6.8. 

Strlcpy issue may be resolved for some. It will need to be tested to see if an addition needs to be made to work with strncpy issue that others have reported.